### PR TITLE
Proposed changes to give user friendlier messages on missing cloneType

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/Builder.scala
@@ -72,6 +72,8 @@ trait InstanceId {
 
 }
 
+class GetReferenceException(message: String) extends Exception(message)
+
 private[chisel3] trait HasId extends InstanceId {
   private[chisel3] def _onModuleClose: Unit = {} // scalastyle:ignore method.name
   private[chisel3] val _parent: Option[BaseModule] = Builder.currentModule
@@ -111,7 +113,7 @@ private[chisel3] trait HasId extends InstanceId {
   private[chisel3] def setRef(parent: HasId, name: String): Unit = setRef(Slot(Node(parent), name))
   private[chisel3] def setRef(parent: HasId, index: Int): Unit = setRef(Index(Node(parent), ILit(index)))
   private[chisel3] def setRef(parent: HasId, index: UInt): Unit = setRef(Index(Node(parent), index.ref))
-  private[chisel3] def getRef: Arg = _ref.get
+  private[chisel3] def getRef: Arg = _ref.getOrElse(throw new GetReferenceException(s"bad .getRef on None"))
   private[chisel3] def getOptionRef: Option[Arg] = _ref
 
   // Implementation of public methods.

--- a/src/main/scala/chisel3/internal/firrtl/Emitter.scala
+++ b/src/main/scala/chisel3/internal/firrtl/Emitter.scala
@@ -49,7 +49,7 @@ private class Emitter(circuit: Circuit) {
           catch {
             case getRef: GetReferenceException =>
               throw new GetReferenceException(s"Cannot emit ports for ${d.className}" +
-                      s" with fields ${d.elements.keys.mkString(",")}, perhaps cloneType is not defined")
+                      s" with fields ${d.elements.keys.mkString(",")}, perhaps you forgot a cloneType")
           }
         case (false, SpecifiedDirection.Flip | SpecifiedDirection.Input) =>
           s"flip ${elt.getRef.name} : ${emitType(elt, false)}"

--- a/src/test/scala/chiselTests/BundleSpec.scala
+++ b/src/test/scala/chiselTests/BundleSpec.scala
@@ -140,6 +140,6 @@ class BundleWithoutCloneTypeProblem extends ChiselPropSpec {
           })
         }
       )
-    }.getMessage should include("Cannot emit ports for Bundle with fields e, perhaps cloneType is not defined")
+    }.getMessage should include("Cannot emit ports for Bundle with fields e, perhaps you forgot a cloneType")
   }
 }


### PR DESCRIPTION
This fix is a stab at providing some useful information
- Add new GetReferenceException to builder
- catch .get on None in emitType on aggregate
- Throw partially filled in GetReferenceException
- provide as much information as possible, which seems to be the field names of the bundle

>I would like to have provided name or line numbers or sourceInfo but neither seem to be available at the necessary points in the stack when the error occurs.